### PR TITLE
fix a few errors

### DIFF
--- a/php_tokyo_tyrant_funcs.h
+++ b/php_tokyo_tyrant_funcs.h
@@ -41,6 +41,6 @@ zend_bool php_tt_iterator_object_init(php_tokyo_tyrant_iterator_object *iterator
 
 void php_tt_tclist_to_array(TCRDB *rdb, TCLIST *res, zval *container TSRMLS_DC);
 
-char *php_tt_prefix(char *key, int key_len, int *new_len TSRMLS_DC);
+zend_string *php_tt_prefix(zend_string *key);
 
 #endif

--- a/tokyo_tyrant.c
+++ b/tokyo_tyrant.c
@@ -425,7 +425,7 @@ PHP_METHOD(tokyotyrant, get)
 	
 	PHP_TOKYO_CONNECTED_OBJECT(intern);
 	
-	if (Z_TYPE_P(key) == IS_ARRAY) {
+	if (Z_TYPE_P(zv_key) == IS_ARRAY) {
 		TCMAP *map = php_tt_zval_to_tcmap(zv_key, 1);
 		tcrdbget3(intern->conn->rdb, map);
 
@@ -471,7 +471,6 @@ PHP_METHOD(tokyotyrant, add)
 	zval *zv_value;
 	zend_bool status = 1;
 
-	char *key, *kbuf;
 	int key_len = 0, new_len, retint;
 	long type = 0;
 	zval *value;


### PR DESCRIPTION
What I can do is pretty limited at this point... hope this helps a bit :smiley: 

One thing I noticed was a parameter for `php_url_parse()`. The functions defined in tcrdb.h also use `char *` instead of zend_string.

```
/vagrant/php-tokyo_tyrant/tokyo_tyrant.c:143: warning: passing argument 1 of ‘php_url_parse’ from incompatible pointer type
/usr/include/php/ext/standard/url.h:35: note: expected ‘const char *’ but argument is of type ‘struct zend_string *’
```
